### PR TITLE
Fix for About Modal image

### DIFF
--- a/packages/management-console/src/components/Molecules/AboutModalComponent/AboutModal.css
+++ b/packages/management-console/src/components/Molecules/AboutModalComponent/AboutModal.css
@@ -1,18 +1,7 @@
 :root {
-  --pf-c-FontColor: black;
-  --p-c-FontWeight: 400;
+
 }
-.pf-c-button pf-m-primary {
-  display: block;
-  width: 100%;
-  padding: var(--pf-c-dropdown__menu-item--PaddingTop) var(--pf-c-dropdown__menu-item--PaddingRight)
-    var(--pf-c-dropdown__menu-item--PaddingBottom) var(--pf-c-dropdown__menu-item--PaddingLeft);
-  font-size: var(--pf-c-dropdown__menu-item--FontSize);
-  font-weight: var(--p-c-FontWeight);
-  line-height: var(--pf-c-dropdown__menu-item--LineHeight);
-  color: var(--pf-c-FontColor);
-  text-align: left;
-  white-space: nowrap;
-  background-color: var(--pf-c-dropdown__menu-item--BackgroundColor);
-  border: none;
+
+.pf-c-about-modal-box__hero {
+  background-attachment: unset;
 }


### PR DESCRIPTION
The background-attachment is causing problems for our image. I'm putting in an issue on PF about it. But we can override it. The other code in this CSS file isn't needed, and actually isn't being applied because of a couple of typos.